### PR TITLE
Remove cuda-cudart-static depency

### DIFF
--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -116,7 +116,7 @@ requirements:
     - cuda-nvcc ={{ cuda_version }}
     - cuda-cccl ={{ cuda_version }}
     - cuda-cudart ={{ cuda_version }}
-    - cuda-cudart-static ={{ cuda_version }}
+    # - cuda-cudart-static ={{ cuda_version }}
     - cuda-driver-dev ={{ cuda_version }}
     - cuda-cudart-dev ={{ cuda_version }}
     - cuda-nvtx ={{ cuda_version }}


### PR DESCRIPTION
For now, we just want to check if the CI will pass without that dependency.