### PR TITLE
Remove obsolete development docs entry

### DIFF
--- a/docs/cupynumeric/switcher.json
+++ b/docs/cupynumeric/switcher.json
@@ -49,10 +49,5 @@
         "preferred": true,
         "url": "https://docs.nvidia.com/cupynumeric/26.06/",
         "version": "26.06"
-    },
-    {
-        "name": "dev",
-        "url": "https://nv-legate.github.io/cupynumeric/",
-        "version": "dev"
     }
 ]


### PR DESCRIPTION
## Summary

Remove the obsolete development documentation entry from the 26.06 switcher.

The final supported documentation remains 26.06. The old GitHub Pages development site will be unpublished separately while retaining its branch history.
